### PR TITLE
[ENHANCEMENT] Raise a different error class when error code is >= 429

### DIFF
--- a/lib/bigcommerce_api/error.rb
+++ b/lib/bigcommerce_api/error.rb
@@ -1,9 +1,12 @@
 module BigcommerceAPI
-  class Error < StandardError
+  class BaseError < StandardError
     attr_reader :code
     def initialize(code, message)
       @code = code
       super(message)
     end
   end
+
+  class Error < BaseError; end
+  class ClientError < BaseError; end
 end

--- a/lib/bigcommerce_api/resource.rb
+++ b/lib/bigcommerce_api/resource.rb
@@ -204,7 +204,12 @@ module BigcommerceAPI
                       else
                         parse_errors(response)
                       end
-            raise BigcommerceAPI::Error.new(response.code, message)
+
+            if response.code >= 429
+              raise BigcommerceAPI::ClientError.new(response.code, message)
+            else
+              raise BigcommerceAPI::Error.new(response.code, message)
+            end
           end
           response
         rescue SocketError => e


### PR DESCRIPTION
Currently we are logging api limit errors because we rescuing `BigcommerceAPI::Error`. Putting 429 errors in a separate class would ensure that we retry those errors in TradeGecko main app